### PR TITLE
feat: theme customizations for ayydany.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -229,3 +229,6 @@ cdn:
   font_awesome: https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css
   justified_gallery_css: https://cdnjs.cloudflare.com/ajax/libs/justifiedGallery/3.8.1/css/justifiedGallery.min.css
   justified_gallery_js: https://cdnjs.cloudflare.com/ajax/libs/justifiedGallery/3.8.1/js/jquery.justifiedGallery.min.js
+
+# Custom title prefix for ayydany // <Title> format
+title_prefix: ayydany

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -68,7 +68,8 @@
   />
   <% } %> <% } %> <% } %>
   <!-- title -->
-  <title><%= page_title() %></title>
+  <% var title_prefix = theme.title_prefix || "ayydany" %>
+  <title><% if (is_home()) { %><%= title_prefix %> // Daniel Carmo<% } else { %><%= title_prefix %> // <%= page_title() %><% } %></title>
   <!-- async scripts -->
   <%- partial('./google_analytics.ejs') %> <%- partial('./umami_analytics.ejs')
   %>

--- a/layout/_partial/post/actions_desktop.ejs
+++ b/layout/_partial/post/actions_desktop.ejs
@@ -20,17 +20,12 @@
         <li><a class="icon" aria-label="<%- __('post.desktop.next') %>" href="<%- url_for(page.next.path) %>"><i class="fa-solid fa-chevron-right" aria-hidden="true" onmouseover="$('#i-next').toggle();" onmouseout="$('#i-next').toggle();"></i></a></li>
         <% } %>
         <li><a class="icon" aria-label="<%- __('post.desktop.back_to_top') %>" href="#" onclick="$('html, body').animate({ scrollTop: 0 }, 'fast');"><i class="fa-solid fa-chevron-up" aria-hidden="true" onmouseover="$('#i-top').toggle();" onmouseout="$('#i-top').toggle();"></i></a></li>
-        <li><a class="icon" aria-label="<%- __('post.desktop.share') %>" href="#"><i class="fa-solid fa-share-alt" aria-hidden="true" onmouseover="$('#i-share').toggle();" onmouseout="$('#i-share').toggle();" onclick="$('#share').toggle();return false;"></i></a></li>
       </ul>
       <span id="i-prev" class="info" style="display:none;"><%= __('post.desktop.previous') %></span>
       <span id="i-next" class="info" style="display:none;"><%= __('post.desktop.next') %></span>
       <span id="i-top" class="info" style="display:none;"><%= __('post.desktop.back_to_top') %></span>
-      <span id="i-share" class="info" style="display:none;"><%= __('post.desktop.share') %></span>
     </span>
     <br/>
-    <div id="share" style="display: none">
-      <%- partial('_partial/post/share', { icon_class_name: '' }) %>
-    </div>
     <% let tocHTML = toc(page.content) %>
     <% if (tocHTML !== '') { %>
       <div id="toc">

--- a/layout/_partial/post/actions_mobile.ejs
+++ b/layout/_partial/post/actions_mobile.ejs
@@ -16,16 +16,11 @@
       </div>
     <% } %>
 
-    <div id="share-footer" style="display: none">
-      <%- partial('_partial/post/share', { icon_class_name: 'fa-lg' }) %>
-    </div>
-
     <div id="actions-footer">
         <a id="menu" class="icon" href="#" onclick="$('#nav-footer').toggle();return false;"><i class="fa-solid fa-bars fa-lg" aria-hidden="true"></i> <%= __('post.mobile.menu') %></a>
         <% if (tocHTML !== '') { %>
           <a id="toc" class="icon" href="#" onclick="$('#toc-footer').toggle();return false;"><i class="fa-solid fa-list fa-lg" aria-hidden="true"></i> <%= __('post.mobile.toc') %></a>
         <% } %>
-        <a id="share" class="icon" href="#" onclick="$('#share-footer').toggle();return false;"><i class="fa-solid fa-share-alt fa-lg" aria-hidden="true"></i> <%= __('post.mobile.share') %></a>
         <a id="top" style="display:none" class="icon" href="#" onclick="$('html, body').animate({ scrollTop: 0 }, 'fast');"><i class="fa-solid fa-chevron-up fa-lg" aria-hidden="true"></i> <%= __('post.mobile.back_to_top') %></a>
     </div>
 

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -232,3 +232,10 @@ code
 
 #header-post #actions
   direction: ltr !important
+
+.callout
+  margin: 1.5rem 0
+  padding: 1rem
+  border-left: 3px solid $color-accent-1
+  background: lighten($color-background, 3%)
+  color: $color-text


### PR DESCRIPTION
# Theme Customizations for ayydany.com

This PR introduces several customizations to the Cactus theme:

- **Configurable Title Prefix:** Added `title_prefix` option in `_config.yml` (defaults to "ayydany"). Titles are now formatted as `prefix // Title`.
- **Callout Styles:** Added a `.callout` class for highlighted info/alert boxes (e.g., for the "Open to connecting" section on the About page).
- **Removed Share Buttons:** Removed social sharing buttons from post action menus (desktop & mobile).
